### PR TITLE
Release: チャット画面のFirefox対応および768〜855px幅のレイアウト修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 
 ## 使用技術（実行環境）
 
--   PHP7.4
+-   PHP8.1
 -   Laravel8.83.27
 -   MySQL8.0.26
 -   Docker
@@ -45,18 +45,19 @@
 
 ## ダミーデータ（Seeder）
 
-開発時に利用できるユーザーアカウントを **4 名分** 作成済みです。  
-プロフィール画像は `src/public/images/seed/avatars/` に準備された画像が `storage/app/public/avatars/` にコピーされ、  
-ユーザーごとに割り当てられます。
+開発時に利用できるユーザーアカウントを **5 名分** 作成済みです。  
+プロフィール画像は `src/public/images/seed/avatars/` に準備された画像が `storage/app/public/avatars/` に  
+コピーされ、ユーザーごとに割り当てられます。
 
 ### 作成されるユーザー一覧
 
-| 名前                 | メールアドレス     | パスワード  | ユーザー名 | プロフィール画像      |
-| -------------------- | ------------------ | ----------- | ---------- | --------------------- |
-| テストユーザー       | test@example.com   | password123 | test_user  | avatars/test_user.png |
-| ユーザー A           | demo_a@example.com | password123 | user_a     | avatars/demo_a.png    |
-| ユーザー B           | demo_b@example.com | password123 | user_b     | avatars/demo_b.png    |
-| ユーザー C（購入者） | demo_c@example.com | password123 | user_c     | avatars/demo_c.png    |
+| 名前                  | メールアドレス     | パスワード  | ユーザー名 | プロフィール画像      |
+| --------------------- | ------------------ | ----------- | ---------- | --------------------- |
+| テストユーザー        | test@example.com   | password123 | test_user  | avatars/test_user.png |
+| ユーザー A            | demo_a@example.com | password123 | user_a     | avatars/demo_a.png    |
+| ユーザー B            | demo_b@example.com | password123 | user_b     | avatars/demo_b.png    |
+| ユーザー C（購入者1）  | demo_c@example.com | password123 | user_c     | avatars/demo_c.png    |
+| ユーザー D（購入者2） | demo_d@example.com | password123 | user_d     | avatars/demo_d.png    |
 
 ---
 

--- a/src/public/css/purchases/chat.css
+++ b/src/public/css/purchases/chat.css
@@ -21,7 +21,7 @@ body {
 .chat-wrap.with-sidebar {
     min-height: 100vh;
     display: grid;
-    grid-template-columns: 240px 1fr;
+    grid-template-columns: 240px minmax(0, 1fr);
 }
 
 /* ---------- サイドバー ---------- */
@@ -76,12 +76,10 @@ body {
 /* ---------- メインチャット ---------- */
 .chat-main {
     border: 1px solid #e5e7eb;
-    overflow: hidden;
-    display: grid;
     padding: 10px 0;
-    grid-template-rows: auto 1fr auto; /* header / timeline / footer */
     min-height: 60vh;
 }
+
 /* プロフィール行 */
 .chat-profile {
     height: 100px;
@@ -171,13 +169,11 @@ body {
     background: #fff5f5;
 }
 
-/* タイムライン（本文だけスクロール） */
+/* タイムライン */
 .chat-timeline {
     padding: 16px;
     display: grid;
     gap: 18px;
-    overflow: auto;
-    -webkit-overflow-scrolling: touch;
 }
 
 /* 行コンテナ：上=ヘッダ(アイコン+名前)、下=吹き出し */
@@ -262,7 +258,9 @@ body {
 
 /* ラッパー：吹き出しとアクションを横並びに */
 .msg-content-wrapper {
-    width: 460px;
+    width: auto;
+    max-width: 100%;
+    min-width: 0;
     display: flex;
     flex-direction: column;
     align-items: flex-end;
@@ -402,7 +400,7 @@ body {
 .chat-textarea {
     flex: 1 1 auto;
     height: 44px;
-    line-height: 44px;
+    line-height: 1.5;
     padding: 0 12px;
     border: 1px solid #5f5f5f;
     border-radius: 4px;
@@ -587,19 +585,25 @@ body {
         gap: 0;
         padding: 8px 16px;
     }
+
     .profile-thumb {
         width: 50px;
         height: 50px;
     }
+
     .profile-name {
         font-weight: bold;
-        flex-grow: 1; /* ボタンを右に押し出す */
+        flex-grow: 1;
         font-size: 20px;
         word-break: break-word;
+        min-width: 0; /* ← 追加 */
     }
+
     .item-name {
         font-size: 40px;
+        word-break: break-word; /* ← 長い商品名対応 */
     }
+
     .chat-profile form {
         display: flex;
         align-items: center;
@@ -609,8 +613,7 @@ body {
         margin: 12px 5px 0;
         border: none;
         border-radius: 50px;
-        font-size: 15px;
-        font-weight: 500;
+        font-size: 13px;
         cursor: pointer;
         line-height: 1.4;
         display: inline-block;
@@ -628,11 +631,68 @@ body {
         height: 50px;
     }
 
-    /* 吹き出し幅を画面に応じて調整 */
+    /* 吹き出し */
     .msg-bubble {
         max-width: 100%;
         width: auto;
         word-wrap: break-word;
+    }
+
+    /* コンテンツラッパーを縮める */
+    .msg-content-wrapper {
+        width: auto;
+        max-width: 100%;
+        min-width: 0;
+    }
+
+    /* チャットメインを縮める */
+    .chat-main {
+        width: 100%;
+        min-width: 0;
+        overflow-x: hidden;
+    }
+
+    .chat-wrap.with-sidebar {
+        min-width: 0;
+    }
+
+    /* 行は1行のまま */
+    .chat-footer {
+        display: flex;
+        flex-wrap: nowrap;
+        align-items: center;
+        gap: 8px;
+    }
+
+    .chat-textarea {
+        flex: 1 1 auto;
+        min-width: 0;
+        height: 44px;
+    }
+
+    .chat-textarea::placeholder {
+        font-size: 15px;
+    }
+
+    /* 右側ボタン群は幅固定寄りにして折り返さない */
+    .input-row {
+        display: inline-flex;
+        flex: 0 0 auto;
+        align-items: center;
+        gap: 8px;
+    }
+
+    /* ラベルが折り返されないように＋少しだけコンパクトに */
+    .input-row label {
+        white-space: nowrap;
+        padding: 6px 10px;
+        font-size: 14px;
+    }
+
+    /* 送信ボタンも少しだけ小さくして余白を確保（任意） */
+    .send-btn {
+        width: 60px;
+        padding: 6px;
     }
 }
 

--- a/src/resources/views/layouts/app.blade.php
+++ b/src/resources/views/layouts/app.blade.php
@@ -95,6 +95,8 @@
         @yield('content')
     </main>
 
+    @yield('scripts')
+
 </body>
 
 </html>

--- a/src/resources/views/purchases/chat.blade.php
+++ b/src/resources/views/purchases/chat.blade.php
@@ -232,29 +232,49 @@ $purchase->status === 'completed' &&
 </div>
 @endif
 
+@section('scripts')
 <script>
     document.addEventListener("DOMContentLoaded", function() {
         // ⭐ 保存キーを URL パスから生成（例: /purchases/5/messages）
         const draftKey = 'chat_draft_' + location.pathname;
         const textarea = document.querySelector('textarea[name="body"]');
+        const form = document.getElementById('chat-form');
 
-        // ⭐ 入力を保存する処理
+        // ⭐ オートリサイズ関数
+        function autoResize(el) {
+            el.style.height = 'auto';
+            el.style.height = el.scrollHeight + 'px';
+        }
+
+        // ⭐ Enterキーでの送信やリロードを防止
+        if (textarea && form) {
+            textarea.addEventListener('keydown', function(e) {
+                if (e.key === 'Enter' && !e.shiftKey) {
+                    e.preventDefault(); // 改行も送信も防ぐ
+                }
+            });
+        }
+
+        // ⭐ 入力保存とオートリサイズ
         if (textarea) {
             textarea.addEventListener('input', () => {
-                localStorage.setItem(draftKey, textarea.value);
+                autoResize(textarea); // 高さを自動調整
+                localStorage.setItem(draftKey, textarea.value); // 入力内容を保存
             });
 
-            // ⭐ ページ読み込み時に draft を復元（リロード時以外）
-            if (performance.navigation.type !== 1 && !textarea.value) {
+            // ⭐ 入力内容の復元（リロード含め常に実行）
+            if (!textarea.value) {
                 const saved = localStorage.getItem(draftKey);
                 if (saved) {
                     textarea.value = saved;
+                    autoResize(textarea); // 復元後にも高さ調整
                 }
+            } else {
+                autoResize(textarea); // 初期に何か入っていた場合もリサイズ
             }
         }
 
         // ⭐ 送信時に draft を削除する
-        const form = document.getElementById('chat-form');
         form?.addEventListener('submit', function() {
             if (textarea) {
                 localStorage.removeItem(draftKey);
@@ -302,3 +322,4 @@ $purchase->status === 'completed' &&
         updateStars(checked ? checked.value : 0);
     });
 </script>
+@endsection


### PR DESCRIPTION
## 概要
developブランチで修正を行った内容をmainブランチに反映します。

## 修正内容
- Firefoxで発生していたQuirks Mode関連の警告を解消
- 768〜855px幅でのチャット画面における横スクロール・表示崩れを修正
- `.msg-content-wrapper` の固定幅を撤廃し、レスポンシブ対応を改善
- `.chat-wrap.with-sidebar` に `minmax(0, 1fr)` を適用して縮小時の見切れを防止
- `.chat-main` の `display:grid` を廃止し、全体スクロール方式に変更

## 動作確認
- Chrome / Firefox で768px〜855px幅を検証し、見切れやスクロール不具合が解消されていることを確認済み
- 全体スクロールに変更したため、ヘッダー・フッターの挙動は想定通りとなっている

## マージ対象
- base: `main`
- compare: `develop`

## 補足
このPRは修正内容のリリースを目的としており、追加の機能開発は含みません。
